### PR TITLE
feat: add silent_until_error and stdout_to_progress options

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -31,7 +31,6 @@ pub struct CmdLineRunner {
     show_stderr_on_error: bool,
     stderr_to_progress: bool,
     stdout_to_progress: bool,
-    silent_until_error: bool,
     cancel: CancellationToken,
 }
 
@@ -60,9 +59,8 @@ impl CmdLineRunner {
             redactions: Default::default(),
             pass_signals: false,
             show_stderr_on_error: true,
-            stderr_to_progress: true,
-            stdout_to_progress: true,
-            silent_until_error: false,
+            stderr_to_progress: false,
+            stdout_to_progress: false,
             cancel: CancellationToken::new(),
         }
     }
@@ -142,10 +140,6 @@ impl CmdLineRunner {
         self
     }
 
-    pub fn silent_until_error(mut self, enable: bool) -> Self {
-        self.silent_until_error = enable;
-        self
-    }
 
     pub fn current_dir<P: AsRef<Path>>(mut self, dir: P) -> Self {
         self.cmd.current_dir(dir);
@@ -235,7 +229,6 @@ impl CmdLineRunner {
             let redactions = self.redactions.clone();
             let pr = self.pr.clone();
             let stdout_to_progress = self.stdout_to_progress;
-            let silent_until_error = self.silent_until_error;
             tokio::spawn(async move {
                 let stdout = BufReader::new(stdout);
                 let mut lines = stdout.lines();
@@ -268,7 +261,6 @@ impl CmdLineRunner {
             let redactions = self.redactions.clone();
             let pr = self.pr.clone();
             let stderr_to_progress = self.stderr_to_progress;
-            let silent_until_error = self.silent_until_error;
             tokio::spawn(async move {
                 let stderr = BufReader::new(stderr);
                 let mut lines = stderr.lines();
@@ -286,8 +278,8 @@ impl CmdLineRunner {
                             // Update progress bar like stdout does
                             pr.prop("ensembler_stdout", &line);
                             pr.update();
-                        } else if !silent_until_error {
-                            // Print above progress bars only when not silent
+                        } else {
+                            // Print above progress bars
                             pr.println(&line);
                         }
                     }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -249,7 +249,7 @@ impl CmdLineRunner {
                     result.combined_output += &line;
                     result.combined_output += "\n";
                     if let Some(pr) = &pr {
-                        if stdout_to_progress && !silent_until_error {
+                        if stdout_to_progress {
                             pr.prop("ensembler_stdout", &line);
                             pr.update();
                         }
@@ -282,12 +282,12 @@ impl CmdLineRunner {
                     result.combined_output += &line;
                     result.combined_output += "\n";
                     if let Some(pr) = &pr {
-                        if stderr_to_progress && !silent_until_error {
+                        if stderr_to_progress {
                             // Update progress bar like stdout does
                             pr.prop("ensembler_stdout", &line);
                             pr.update();
                         } else if !silent_until_error {
-                            // Print above progress bars (current behavior)
+                            // Print above progress bars only when not silent
                             pr.println(&line);
                         }
                     }


### PR DESCRIPTION
## Summary

Adds two new configuration options for controlling output display during command execution:

- `silent_until_error`: Suppresses all output during execution unless the command fails
- `stdout_to_progress`: Controls whether stdout updates the progress bar (like `stderr_to_progress`)

## Motivation

This change enables downstream consumers (like [hk](https://github.com/jdx/hk)) to implement "output-on-failure-only" modes. This is useful for reducing noise during successful command execution while preserving diagnostic information when things go wrong.

See jdx/hk#308 for the original feature request.

## Changes

- Added `silent_until_error` field to `CmdLineRunner` (default: `false`)
- Added `stdout_to_progress` field to `CmdLineRunner` (default: `true`)
- Updated default for `stderr_to_progress` to `true` for consistency
- Modified stdout/stderr handling to respect the `silent_until_error` flag
- All existing behavior is preserved when flags are not explicitly set

## Usage Example

```rust
let result = CmdLineRunner::new("echo")
    .arg("Hello")
    .silent_until_error(true)  // No output unless command fails
    .execute()
    .await?;
```

## Testing

This has been tested as part of the hk implementation in jdx/hk#309