### PR TITLE
feat(cmd): add new_direct and raw_arg for Windows quoting

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -78,13 +78,26 @@ impl CmdLineRunner {
     /// The command is configured with piped stdout/stderr and null stdin by default.
     pub fn new<P: AsRef<OsStr>>(program: P) -> Self {
         let program = program.as_ref().to_string_lossy().to_string();
-        let mut cmd = if cfg!(windows) {
+        let cmd = if cfg!(windows) {
             let mut cmd = Command::new("cmd.exe");
             cmd.arg("/c").arg(&program);
             cmd
         } else {
             Command::new(&program)
         };
+        Self::init(cmd, program)
+    }
+
+    /// Create a runner that invokes `program` directly, bypassing the
+    /// Windows auto-wrap in `cmd.exe /c`. Use this when you need precise
+    /// control over the command line (e.g. to pair with [`raw_arg`]).
+    pub fn new_direct<P: AsRef<OsStr>>(program: P) -> Self {
+        let program = program.as_ref().to_string_lossy().to_string();
+        let cmd = Command::new(&program);
+        Self::init(cmd, program)
+    }
+
+    fn init(mut cmd: Command, program: String) -> Self {
         cmd.stdin(Stdio::null());
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());
@@ -345,6 +358,31 @@ impl CmdLineRunner {
     pub fn arg<S: AsRef<OsStr>>(mut self, arg: S) -> Self {
         self.cmd.arg(arg.as_ref());
         self.args.push(arg.as_ref().to_string_lossy().to_string());
+        self
+    }
+
+    /// Append a raw, unescaped fragment to the command line on Windows.
+    ///
+    /// Rust's `Command::arg` applies MSVCRT-style argv escaping on Windows,
+    /// which collides with `cmd.exe`'s own parsing rules and mangles strings
+    /// that already contain cmd-appropriate quoting. This method uses
+    /// `CommandExt::raw_arg` to append the string verbatim so shell-quoted
+    /// payloads (like rendered `{{files}}` values) survive intact.
+    ///
+    /// On non-Windows platforms this falls back to a regular `arg`.
+    #[allow(unused_mut)]
+    pub fn raw_arg<S: AsRef<OsStr>>(mut self, arg: S) -> Self {
+        let s = arg.as_ref().to_string_lossy().to_string();
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            self.cmd.as_std_mut().raw_arg(&s);
+        }
+        #[cfg(not(windows))]
+        {
+            self.cmd.arg(arg.as_ref());
+        }
+        self.args.push(s);
         self
     }
 


### PR DESCRIPTION
## Summary

- Add `CmdLineRunner::new_direct` which skips the Windows auto `cmd.exe /c` wrapping so callers can construct cmd.exe invocations precisely.
- Add `CmdLineRunner::raw_arg` which appends a fragment verbatim via `CommandExt::raw_arg`, bypassing Rust's MSVCRT-style re-escaping. Falls back to `arg` on non-Windows.

## Why

On Windows, `Command::arg` applies MSVCRT argv escaping which conflicts with `cmd.exe`'s own quoting rules. Strings that are already shell-quoted for cmd.exe (e.g. rendered `{{files}}` values in hk) get mangled — cmd.exe sees literal `"` characters in tool arguments, which silently corrupts file paths passed to linters. See jdx/hk#823 for the downstream bug.

## Test plan

- [ ] Consumed by hk; regression covered by a new Pester e2e test in that repo.
- [ ] Cross-compile ensembler for `x86_64-pc-windows-gnu` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how Windows command lines can be constructed and introduces a `raw_arg` path that bypasses normal argument escaping, which could affect command execution/quoting behavior if misused.
> 
> **Overview**
> Adds opt-in APIs to better control Windows command invocation and quoting in `CmdLineRunner`.
> 
> `CmdLineRunner::new_direct` allows bypassing the default Windows `cmd.exe /c` wrapper, and `CmdLineRunner::raw_arg` uses `CommandExt::raw_arg` on Windows to append unescaped fragments (falling back to `arg` elsewhere), avoiding double-escaping for already shell-quoted payloads; construction is refactored through a shared `init` helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4ab94bae318d8222ad66bd8cfafe0e0c52d0916. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->