### PR TITLE
chore: release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.1.0](https://github.com/jdx/ensembler/compare/v1.0.2...v1.1.0) - 2026-04-12
+
+### Added
+
+- *(cmd)* add new_direct and raw_arg for Windows quoting ([#89](https://github.com/jdx/ensembler/pull/89))
+
 ## [1.0.2](https://github.com/jdx/ensembler/compare/v1.0.1...v1.0.2) - 2026-02-22
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "ensembler"
-version = "1.0.2"
+version = "1.1.0"
 dependencies = [
  "aho-corasick",
  "clx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ensembler"
-version = "1.0.2"
+version = "1.1.0"
 edition = "2021"
 repository = "https://github.com/jdx/ensembler"
 homepage = "https://github.com/jdx/ensembler"


### PR DESCRIPTION



## 🤖 New release

* `ensembler`: 1.0.2 -> 1.1.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.0](https://github.com/jdx/ensembler/compare/v1.0.2...v1.1.0) - 2026-04-12

### Added

- *(cmd)* add new_direct and raw_arg for Windows quoting ([#89](https://github.com/jdx/ensembler/pull/89))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: version bumps and changelog updates with no functional code changes in this PR.
> 
> **Overview**
> Updates the crate version from `1.0.2` to `1.1.0` in `Cargo.toml`/`Cargo.lock` and adds the `v1.1.0` entry to `CHANGELOG.md` (noting the new Windows quoting args `new_direct`/`raw_arg`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17815f7b63e88438e5a035cce652d2bb806e71ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->