### PR TITLE
chore: release v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.1.1](https://github.com/jdx/ensembler/compare/v1.1.0...v1.1.1) - 2026-04-17
+
+### Fixed
+
+- *(deps)* update rust crate clx to v2 ([#93](https://github.com/jdx/ensembler/pull/93))
+
 ## [1.1.0](https://github.com/jdx/ensembler/compare/v1.0.2...v1.1.0) - 2026-04-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "ensembler"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "aho-corasick",
  "clx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ensembler"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 repository = "https://github.com/jdx/ensembler"
 homepage = "https://github.com/jdx/ensembler"


### PR DESCRIPTION



## 🤖 New release

* `ensembler`: 1.1.0 -> 1.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.1](https://github.com/jdx/ensembler/compare/v1.1.0...v1.1.1) - 2026-04-17

### Fixed

- *(deps)* update rust crate clx to v2 ([#93](https://github.com/jdx/ensembler/pull/93))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release-only change: updates crate version metadata and changelog, with no functional code changes in this PR. Runtime behavior should be unchanged aside from consumers resolving the updated `clx` dependency version declared in `Cargo.toml`.
> 
> **Overview**
> Updates release metadata for `v1.1.1` by bumping the crate version in `Cargo.toml`/`Cargo.lock` and adding a `CHANGELOG.md` entry noting the `clx` dependency upgrade to `v2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e89f7789a495fba2ea6724152eb6794046ef8360. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->