### PR TITLE
chore: release v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.1.2](https://github.com/jdx/ensembler/compare/v1.1.1...v1.1.2) - 2026-05-03
+
+### Other
+
+- set dev profile debug to 1 ([#97](https://github.com/jdx/ensembler/pull/97))
+
 ## [1.1.1](https://github.com/jdx/ensembler/compare/v1.1.0...v1.1.1) - 2026-04-17
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "ensembler"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "aho-corasick",
  "clx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ensembler"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 repository = "https://github.com/jdx/ensembler"
 homepage = "https://github.com/jdx/ensembler"


### PR DESCRIPTION



## 🤖 New release

* `ensembler`: 1.1.1 -> 1.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.2](https://github.com/jdx/ensembler/compare/v1.1.1...v1.1.2) - 2026-05-03

### Other

- set dev profile debug to 1 ([#97](https://github.com/jdx/ensembler/pull/97))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: version bumps and changelog update, with no functional code changes beyond dev build debug settings.
> 
> **Overview**
> Bumps the crate version to `1.1.2` (including `Cargo.toml`/`Cargo.lock`) and updates `CHANGELOG.md` for the new release.
> 
> Also sets `[profile.dev].debug = 1`, affecting *dev builds only*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fda7949e3451443b0155d7428672787464f5a892. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->