### PR TITLE
chore: release v1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.1.3](https://github.com/jdx/ensembler/compare/v1.1.2...v1.1.3) - 2026-07-28
+
+### Fixed
+
+- *(deps)* update rust crate clx to v3 ([#121](https://github.com/jdx/ensembler/pull/121))
+
 ## [1.1.2](https://github.com/jdx/ensembler/compare/v1.1.1...v1.1.2) - 2026-05-03
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,7 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "ensembler"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "aho-corasick",
  "clx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ensembler"
-version = "1.1.2"
+version = "1.1.3"
 edition = "2021"
 repository = "https://github.com/jdx/ensembler"
 homepage = "https://github.com/jdx/ensembler"


### PR DESCRIPTION



## 🤖 New release

* `ensembler`: 1.1.2 -> 1.1.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.3](https://github.com/jdx/ensembler/compare/v1.1.2...v1.1.3) - 2026-07-28

### Fixed

- *(deps)* update rust crate clx to v3 ([#121](https://github.com/jdx/ensembler/pull/121))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine version and changelog release with no application logic changes in this diff; dependency bump is scoped to optional progress UI integration.
> 
> **Overview**
> **Release v1.1.3** — bumps the crate version from **1.1.2** to **1.1.3** in `Cargo.toml` and `Cargo.lock`, and adds a **CHANGELOG** entry for this release.
> 
> The documented change under this version is the **dependency update** to Rust crate **`clx` v3** ([#121](https://github.com/jdx/ensembler/pull/121)); `Cargo.toml` already pins `clx = { version = "3", optional = true }` for the optional `progress` feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d39efa3595b157970a95c147d7af3019ffe8dc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->